### PR TITLE
Add more build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
-.build
 *.bak
-*.swp
+*.o
 *.swo
-*.tdy
+*.swp
 *.tar.gz
+*.tdy
+.build
+Build
 Crypt-Argon2-*
+_build
+blib
+lib/Crypt/Argon2.c


### PR DESCRIPTION
Useful if you run Build.PL directly instead of through dzil.